### PR TITLE
Adding support for Consul token to be configured in MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ npm run build
 Create a `.env` file in the root directory with the following variables:
 
 ```
-CONSUL_ADDR=http://localhost:8500
+CONSUL_HTTP_ADDR=http://localhost:8500
+CONSUL_HTTP_TOKEN=your-consul-token
 PORT=3000
 USE_HTTP=true
 ```
 
-* `CONSUL_ADDR`: Address of your Consul server
+* `CONSUL_HTTP_ADDR`: Address of your Consul server
+* `CONSUL_HTTP_TOKEN`: ACL token of your Consul server
 * `PORT`: Port for the HTTP server
 * `USE_HTTP`: Set to "true" for HTTP mode, omit for stdio mode
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ To install and use this MCP server in Claude Desktop:
 }
 ```
 
+if the server is not local host or ACL is enabled, use below configuration instead
+```json
+{
+    "mcpServers": {
+      "consul-assistant": {
+        "command": "npx",
+        "args": ["-y", "consul-mcp-server"],
+        "env": {
+          "CONSUL_HTTP_ADDR": "http://<host/ip>:8500",
+          "CONSUL_HTTP_TOKEN": "<ACL Token>"
+        }
+      }
+    }
+  }
+```
+
 4. Restart Claude Desktop to ensure the MCP server is properly loaded.
 
 ## Example Prompts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "consul-mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "consul-mcp-server",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.8.0",
@@ -17,6 +17,9 @@
         "mermaid": "^10.6.0",
         "node-fetch": "^3.3.2",
         "zod": "^3.22.4"
+      },
+      "bin": {
+        "consul-mcp-server": "dist/index.js"
       },
       "devDependencies": {
         "@types/consul": "^0.40.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { ServiceAnalyzer } from './tools/status-analyzer.js';
 config();
 
 // Default configuration values
-const DEFAULT_CONSUL_ADDR = 'http://localhost:8500';
+const DEFAULT_CONSUL_HTTP_ADDR = 'http://localhost:8500';
 const SERVER_NAME = "consul-mcp-server";
 const VERSION = "0.1.0";
 
@@ -36,13 +36,14 @@ const VERSION = "0.1.0";
 
 async function main() {
   try {
-    const consulAddr = process.env.CONSUL_ADDR || DEFAULT_CONSUL_ADDR;
+    const consulAddr = process.env.CONSUL_HTTP_ADDR || DEFAULT_CONSUL_HTTP_ADDR;
+    const consulToken = process.env.CONSUL_HTTP_TOKEN || undefined;
     
     console.error(`Starting Consul MCP Server...`);
     console.error(`Connecting to Consul at: ${consulAddr}`);
     
     // Initialize Consul client
-    const consulClient = await createConsulClient(consulAddr);
+    const consulClient = await createConsulClient(consulAddr, consulToken);
     
     // Initialize service managers
     const serviceManager = new ServiceManager(consulClient);

--- a/src/resources/consul-client.ts
+++ b/src/resources/consul-client.ts
@@ -278,7 +278,7 @@ export class ConsulClient {
   }
 }
 
-export async function createConsulClient(consulAddr: string): Promise<ConsulClient> {
+export async function createConsulClient(consulAddr: string, consulToken: string | undefined): Promise<ConsulClient> {
   let host = 'localhost';
   let port = 8500;
   let secure = false;
@@ -302,7 +302,10 @@ export async function createConsulClient(consulAddr: string): Promise<ConsulClie
     host,
     port: port.toString(), // 👈 convert number to string
     secure,
-    promisify: true
+    promisify: true,
+    defaults: {
+      token: consulToken
+    }
   });
   
   return new ConsulClient(client);


### PR DESCRIPTION
## Description
Adding support for Consul token to be configured in MCP server

## Recommended Claude MCP config
```json
{
    "mcpServers": {
      "consul-assistant": {
        "command": "npx",
        "args": ["-y", "consul-mcp-server"],
        "env": {
          "CONSUL_HTTP_ADDR": "http://<host/ip>:8500",
          "CONSUL_HTTP_TOKEN": "<ACL Token>"
        }
      }
    }
  }
```